### PR TITLE
reverse the order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,8 +109,8 @@ jobs:
       # NOTE: because this doesn't build with the kubernetes tag, it will not run the kubernetes tests. See
       # kubernetes_test build steps.
       - run: mkdir -p /tmp/logs
-      - run: run-go-tests --packages "-p 1 ./..." | tee /tmp/logs/test_output.log
       - run: run-go-tests --packages "-p 1 -tags=special -run TestRunCommandWithHugeLineOutput ./modules/shell"
+      - run: run-go-tests --packages "-p 1 ./..." | tee /tmp/logs/test_output.log
 
       - run:
           command: ./cmd/bin/terratest_log_parser_linux_amd64 --testlog /tmp/logs/test_output.log --outputdir /tmp/logs


### PR DESCRIPTION
That way bugs in the special test are found before running the long test suite.